### PR TITLE
fix: add conditional compilation for MLX version compatibility

### DIFF
--- a/mlx/mlx_compat.h
+++ b/mlx/mlx_compat.h
@@ -1,0 +1,90 @@
+#pragma once
+/// @file mlx_compat.h
+/// @brief MLX version compatibility layer for mlx-llm.cpp
+///
+/// This header provides compatibility macros and type aliases to support
+/// both MLX <0.30 and MLX >=0.30 APIs without source code modifications.
+
+#include <mlx/mlx.h>
+
+//==============================================================================
+// Version Detection
+//==============================================================================
+
+/// Check if MLX version is at least major.minor.patch
+/// MLX_VERSION_NUMERIC = 100000*MAJOR + 1000*MINOR + PATCH
+#define MLX_VERSION_AT_LEAST(major, minor, patch) \
+  (MLX_VERSION_NUMERIC >= (100000 * (major) + 1000 * (minor) + (patch)))
+
+/// Convenience macro for MLX 0.30+ detection
+#define MLX_0_30_OR_LATER MLX_VERSION_AT_LEAST(0, 30, 0)
+
+//==============================================================================
+// Shape Type Compatibility
+//==============================================================================
+// MLX 0.30+ changed array.shape() return type from std::vector<int> to
+// mx::Shape (SmallVector<int32_t>). Both types support the same operations
+// (size(), operator[], begin(), end(), insert(), push_back()), so using
+// 'auto' is the most portable approach. For explicit type declarations,
+// use these aliases:
+
+#if MLX_0_30_OR_LATER
+using MlxShape = mx::Shape;
+using MlxStrides = mx::Strides;
+#else
+using MlxShape = std::vector<int>;
+using MlxStrides = std::vector<int64_t>;
+#endif
+
+//==============================================================================
+// Quantize Result Access
+//==============================================================================
+// MLX 0.30+ changed mx::quantize() return type from
+// std::tuple<mx::array, mx::array, mx::array> to std::vector<mx::array>.
+// These macros provide unified access to the quantize results.
+
+#if MLX_0_30_OR_LATER
+#define MLX_QUANTIZE_WEIGHTS(q) ((q)[0])
+#define MLX_QUANTIZE_SCALES(q) ((q)[1])
+#define MLX_QUANTIZE_BIASES(q) ((q)[2])
+#else
+#define MLX_QUANTIZE_WEIGHTS(q) (std::get<0>(q))
+#define MLX_QUANTIZE_SCALES(q) (std::get<1>(q))
+#define MLX_QUANTIZE_BIASES(q) (std::get<2>(q))
+#endif
+
+//==============================================================================
+// Scaled Dot Product Attention Wrapper
+//==============================================================================
+// MLX 0.30+ added a 'mask_mode' string parameter to
+// mx::fast::scaled_dot_product_attention(). This wrapper provides a
+// unified interface that works with both old and new APIs.
+
+namespace mlx_compat {
+
+/// @brief Version-compatible wrapper for scaled_dot_product_attention
+/// @param queries Query tensor [batch, heads, seq_len, head_dim]
+/// @param keys Key tensor [batch, heads, kv_len, head_dim]
+/// @param values Value tensor [batch, heads, kv_len, head_dim]
+/// @param scale Attention scale factor (typically 1/sqrt(head_dim))
+/// @param mask Optional attention mask
+/// @return Attention output tensor
+inline mx::array scaled_dot_product_attention(
+    const mx::array &queries, const mx::array &keys, const mx::array &values,
+    float scale, std::optional<mx::array> mask = std::nullopt) {
+#if MLX_0_30_OR_LATER
+  if (mask.has_value()) {
+    return mx::fast::scaled_dot_product_attention(queries, keys, values, scale,
+                                                  "", mask.value());
+  }
+  return mx::fast::scaled_dot_product_attention(queries, keys, values, scale);
+#else
+  if (mask.has_value()) {
+    return mx::fast::scaled_dot_product_attention(queries, keys, values, scale,
+                                                  mask.value());
+  }
+  return mx::fast::scaled_dot_product_attention(queries, keys, values, scale);
+#endif
+}
+
+} // namespace mlx_compat

--- a/mlx/pooling.cpp
+++ b/mlx/pooling.cpp
@@ -1,5 +1,6 @@
 #include "pooling.h"
 #include "base.h"
+#include "mlx_compat.h"
 #include "spdlog/spdlog.h"
 #include <cstdint>
 #include <mlx/array.h>
@@ -32,9 +33,9 @@ makePadShape(const std::vector<std::pair<int, int>> &Padding, int TotalDims) {
 } // namespace
 
 mx::array nonOverlappingSlidingWindows(const mx::array &X,
-                                       const std::vector<int> &Shape,
+                                       const MlxShape &Shape,
                                        const std::vector<int> &WindowShape) {
-  std::vector<int> NewShape;
+  MlxShape NewShape;
   NewShape.push_back(Shape[0]);
   for (size_t I = 1; I < std::min(Shape.size(), WindowShape.size() + 1); I++) {
     int S = Shape[I];
@@ -66,7 +67,7 @@ mx::array slidingWindows(const mx::array &X,
         std::to_string(X.ndim()) + " dimensions.");
     assumingUnreachable();
   }
-  std::vector<int> Shape = X.shape();
+  auto Shape = X.shape();
   size_t SpatialDimsCount = Shape.size() - 2;
   if (SpatialDimsCount != WindowShape.size() ||
       WindowShape.size() != WindowStrides.size()) {
@@ -92,7 +93,7 @@ mx::array slidingWindows(const mx::array &X,
   for (int I = N - 2; I >= 0; I--) {
     BaseStrides[I] = Shape[I + 1] * BaseStrides[I + 1];
   }
-  std::vector<int> FinalShape;
+  MlxShape FinalShape;
   FinalShape.push_back(Shape[0]);
   for (size_t I = 0; I < SpatialDimsCount; I++) {
     int OutDim = (Shape[I + 1] - WindowShape[I]) / WindowStrides[I] + 1;
@@ -100,7 +101,7 @@ mx::array slidingWindows(const mx::array &X,
   }
   FinalShape.insert(FinalShape.end(), WindowShape.begin(), WindowShape.end());
   FinalShape.push_back(Shape.back());
-  std::vector<int64_t> FinalStrides;
+  MlxStrides FinalStrides;
   FinalStrides.push_back(BaseStrides[0]);
   for (size_t I = 1; I < BaseStrides.size() - 1; I++) {
     FinalStrides.push_back(BaseStrides[I] * WindowStrides[I - 1]);

--- a/mlx/quantized.cpp
+++ b/mlx/quantized.cpp
@@ -30,11 +30,12 @@ QuantizedEmbedding::fromEmbedding(std::shared_ptr<Embedding> EmbeddingModule,
       EmbeddingShape[0], EmbeddingShape[1], GroupSize, Bits));
   auto Quantized =
       mx::quantize(EmbeddingModule->Parameters.at("weight"), GroupSize, Bits);
-  QuantizedModel->Parameters.insert_or_assign("weight", std::get<0>(Quantized));
+  QuantizedModel->Parameters.insert_or_assign("weight",
+                                              MLX_QUANTIZE_WEIGHTS(Quantized));
   QuantizedModel->Parameters.insert_or_assign(
-      "scales", std::move(std::get<1>(Quantized)));
+      "scales", std::move(MLX_QUANTIZE_SCALES(Quantized)));
   QuantizedModel->Parameters.insert_or_assign(
-      "biases", std::move(std::get<2>(Quantized)));
+      "biases", std::move(MLX_QUANTIZE_BIASES(Quantized)));
   return QuantizedModel;
 }
 std::shared_ptr<QuantizedLinear>
@@ -49,11 +50,12 @@ QuantizedLinear::fromLinear(std::shared_ptr<Linear> LinearModule, int GroupSize,
       QuantizedLinear(InputDims, OutputDims, EnableBias, GroupSize, Bits));
   auto Quantized =
       mx::quantize(LinearModule->Parameters.at("weight"), GroupSize, Bits);
-  QuantizedModel->Parameters.insert_or_assign("weight", std::get<0>(Quantized));
+  QuantizedModel->Parameters.insert_or_assign("weight",
+                                              MLX_QUANTIZE_WEIGHTS(Quantized));
   QuantizedModel->Parameters.insert_or_assign(
-      "scales", std::move(std::get<1>(Quantized)));
+      "scales", std::move(MLX_QUANTIZE_SCALES(Quantized)));
   QuantizedModel->Parameters.insert_or_assign(
-      "biases", std::move(std::get<2>(Quantized)));
+      "biases", std::move(MLX_QUANTIZE_BIASES(Quantized)));
   if (EnableBias) {
     QuantizedModel->Parameters.insert_or_assign(
         "bias", LinearModule->Parameters.at("bias"));

--- a/mlx/quantized.h
+++ b/mlx/quantized.h
@@ -2,6 +2,7 @@
 #include "base.h"
 #include "embedding.h"
 #include "linear.h"
+#include "mlx_compat.h"
 #include <mlx/array.h>
 #include <mlx/ops.h>
 
@@ -21,9 +22,9 @@ public:
     registerParameter("weight",
                       mx::random::normal({NumEmbeddings, Dims}, 0.0, Scale));
     auto Quantized = mx::quantize(Parameters.at("weight"), GroupSize, Bits);
-    Parameters.insert_or_assign("weight", std::get<0>(Quantized));
-    registerParameter("scales", std::move(std::get<1>(Quantized)));
-    registerParameter("biases", std::move(std::get<2>(Quantized)));
+    Parameters.insert_or_assign("weight", MLX_QUANTIZE_WEIGHTS(Quantized));
+    registerParameter("scales", std::move(MLX_QUANTIZE_SCALES(Quantized)));
+    registerParameter("biases", std::move(MLX_QUANTIZE_BIASES(Quantized)));
   }
   mx::array forward(mx::array Input) override;
   static std::shared_ptr<QuantizedEmbedding>
@@ -42,9 +43,9 @@ public:
     registerParameter(
         "weight", mx::random::uniform(-Scale, Scale, {OutputDim, InputDims}));
     auto Quantized = mx::quantize(Parameters.at("weight"), GroupSize, Bits);
-    Parameters.insert_or_assign("weight", std::get<0>(Quantized));
-    registerParameter("scales", std::move(std::get<1>(Quantized)));
-    registerParameter("biases", std::move(std::get<2>(Quantized)));
+    Parameters.insert_or_assign("weight", MLX_QUANTIZE_WEIGHTS(Quantized));
+    registerParameter("scales", std::move(MLX_QUANTIZE_SCALES(Quantized)));
+    registerParameter("biases", std::move(MLX_QUANTIZE_BIASES(Quantized)));
     if (Bias) {
       registerParameter("bias", mx::zeros({OutputDim}));
     }

--- a/model/gemma3/language.cpp
+++ b/model/gemma3/language.cpp
@@ -1,4 +1,5 @@
 #include "language.h"
+#include "../../mlx/mlx_compat.h"
 #include "activations.h"
 #include "base.h"
 #include "embedding.h"
@@ -137,16 +138,14 @@ mx::array Attention::forward(
     mx::array M =
         take(Mask.value(), {-Keys.shape().at(Keys.shape().size() - 2)}, -1);
     return std::dynamic_pointer_cast<nn::Linear>(Submodules["o_proj"])
-        ->forward(transpose(reshape(mx::fast::scaled_dot_product_attention(
-                                        Queries, Keys, Values, Scale, M),
-                                    {B, L, -1}),
-                            {0, 2, 1}));
+        ->forward(transpose(
+            reshape(mlx_compat::scaled_dot_product_attention(Queries, Keys,
+                                                             Values, Scale, M),
+                    {B, L, -1}),
+            {0, 2, 1}));
   }
-  auto Output = (Mask.has_value()
-                     ? mx::fast::scaled_dot_product_attention(
-                           Queries, Keys, Values, Scale, Mask.value())
-                     : mx::fast::scaled_dot_product_attention(Queries, Keys,
-                                                              Values, Scale));
+  auto Output = mlx_compat::scaled_dot_product_attention(Queries, Keys, Values,
+                                                         Scale, Mask);
   Output = reshape(transpose(Output, {0, 2, 1, 3}), {B, L, -1});
   return std::dynamic_pointer_cast<nn::Linear>(Submodules["o_proj"])
       ->forward(Output);

--- a/model/gemma3/vision.cpp
+++ b/model/gemma3/vision.cpp
@@ -1,4 +1,5 @@
 #include "vision.h"
+#include "../../mlx/mlx_compat.h"
 #include "activations.h"
 #include "convolution.h"
 #include "embedding.h"
@@ -99,10 +100,8 @@ mx::array VisionAttention::forward(const mx::array &X,
   Keys = transpose(reshape(Keys, {B, S, NumHeads, -1}), {0, 2, 1, 3});
   Values = transpose(reshape(Values, {B, S, NumHeads, -1}), {0, 2, 1, 3});
   mx::array Output =
-      Mask.has_value() ? mx::fast::scaled_dot_product_attention(
-                             Queries, Keys, Values, Scale, Mask.value())
-                       : mx::fast::scaled_dot_product_attention(Queries, Keys,
-                                                                Values, Scale);
+      mlx_compat::scaled_dot_product_attention(Queries, Keys, Values, Scale,
+                                               Mask);
   Output = reshape(transpose(Output, {0, 2, 1, 3}), {B, L, -1});
   return std::dynamic_pointer_cast<nn::Linear>(Submodules["out_proj"])
       ->forward(Output);

--- a/model/llm/transformer.cpp
+++ b/model/llm/transformer.cpp
@@ -1,4 +1,5 @@
-#include "../mlx/transformer.h"
+#include "../../mlx/transformer.h"
+#include "../../mlx/mlx_compat.h"
 #include "../utils.h"
 #include "base.h"
 #include "embedding.h"
@@ -56,10 +57,8 @@ Attention::forward(mx::array Input, std::optional<mx::array> Mask,
         std::dynamic_pointer_cast<nn::RoPE>(Submodules["rope"])->forward(Keys);
   }
   mx::array Output =
-      Mask.has_value() ? mx::fast::scaled_dot_product_attention(
-                             Queries, Keys, Values, Scale, Mask.value())
-                       : mx::fast::scaled_dot_product_attention(Queries, Keys,
-                                                                Values, Scale);
+      mlx_compat::scaled_dot_product_attention(Queries, Keys, Values, Scale,
+                                               Mask);
 
   Output = reshape(transpose(Output, {0, 2, 1, 3}), {B, L, -1});
   return {std::dynamic_pointer_cast<nn::Linear>(Submodules["o_proj"])
@@ -179,7 +178,7 @@ std::tuple<mx::array,
            std::optional<std::vector<std::tuple<mx::array, mx::array>>>>
 Transformer::stepGenerate(mx::array Input, std::optional<float> Temp) {
   // Reshape Input to input[:, None]
-  std::vector<int> ReshapeDim = Input.shape();
+  auto ReshapeDim = Input.shape();
   ReshapeDim.insert(ReshapeDim.begin(), 1);
   auto [Logits, KVCache] = forward(reshape(Input, ReshapeDim));
   const int H = Logits.shape()[1] - 1;
@@ -202,7 +201,7 @@ Transformer::nextStepGenerate(
     mx::array Y, std::optional<float> Temp,
     std::optional<std::vector<std::tuple<mx::array, mx::array>>> KVCachePar) {
   // Reshape Y to y[:, None]
-  std::vector<int> ReshapeDim = Y.shape();
+  auto ReshapeDim = Y.shape();
   ReshapeDim.insert(ReshapeDim.begin() + 1, 1);
   auto [Logits, KVCache] = forward(reshape(Y, ReshapeDim), KVCachePar);
   Logits = squeeze(Logits, 1);

--- a/model/mllama/language.cpp
+++ b/model/mllama/language.cpp
@@ -1,4 +1,5 @@
 #include "language.h"
+#include "../../mlx/mlx_compat.h"
 #include "embedding.h"
 #include "linear.h"
 #include <algorithm>
@@ -144,13 +145,8 @@ mx::array MllamaTextCrossAttention::forward(
     KeyStates = std::dynamic_pointer_cast<nn::RMSNorm>(Submodules["k_norm"])
                     ->forward(KeyStates);
   }
-  mx::array AttnOutput =
-      AttentionMask.has_value()
-          ? mx::fast::scaled_dot_product_attention(QueryStates, KeyStates,
-                                                   ValueStates, Scale,
-                                                   AttentionMask.value())
-          : mx::fast::scaled_dot_product_attention(QueryStates, KeyStates,
-                                                   ValueStates, Scale);
+  mx::array AttnOutput = mlx_compat::scaled_dot_product_attention(
+      QueryStates, KeyStates, ValueStates, Scale, AttentionMask);
 
   AttnOutput = reshape(transpose(AttnOutput, {0, 2, 1, 3}),
                        {BatchSize, QLen, HiddenSize});
@@ -218,12 +214,8 @@ MllamaTextSelfAttention::forward(const mx::array &X,
                     ->forward(KeyStates);
   }
 
-  mx::array AttnOutput =
-      Mask.has_value()
-          ? mx::fast::scaled_dot_product_attention(
-                QueryStates, KeyStates, ValueStates, Scale, Mask.value())
-          : mx::fast::scaled_dot_product_attention(QueryStates, KeyStates,
-                                                   ValueStates, Scale);
+  mx::array AttnOutput = mlx_compat::scaled_dot_product_attention(
+      QueryStates, KeyStates, ValueStates, Scale, Mask);
   AttnOutput = reshape(transpose(AttnOutput, {0, 2, 1, 3}),
                        {BatchSize, QLen, HiddenSize});
   return std::dynamic_pointer_cast<nn::Linear>(Submodules["o_proj"])

--- a/model/mllama/vision.cpp
+++ b/model/mllama/vision.cpp
@@ -1,4 +1,5 @@
 #include "vision.h"
+#include "../../mlx/mlx_compat.h"
 #include "activations.h"
 #include <cmath>
 #include <mlx/array.h>
@@ -149,11 +150,8 @@ MllamaVisionAttention::forward(const mx::array &HiddenState,
     mx::array Indices = mx::arange(Key.shape()[Key.size() - 3]);
     MaskOpt = take(MaskOpt.value(), Indices, -2);
   }
-  mx::array AttnOutput =
-      MaskOpt.has_value()
-          ? mx::fast::scaled_dot_product_attention(Query, Key, Value, Scale,
-                                                   MaskOpt.value())
-          : mx::fast::scaled_dot_product_attention(Query, Key, Value, Scale);
+  mx::array AttnOutput = mlx_compat::scaled_dot_product_attention(
+      Query, Key, Value, Scale, MaskOpt);
   AttnOutput = reshape(transpose(AttnOutput, {0, 2, 1, 3}),
                        {BatchSize, QSeqLen, EmbedDim});
   return std::dynamic_pointer_cast<nn::Linear>(Submodules["o_proj"])
@@ -306,8 +304,8 @@ mx::array _prepareAspectRatioAttentionMask(const mx::array &AspectRatioMask,
   int PadPatches = TargetLength - NumPatches;
   // attention_mask[:, :, -pad_patches:] = 0
   auto End = Mask.shape();
-  std::vector<int> Start(End.size(), 0);
-  std::vector<int> Stride(End.size(), 1);
+  MlxShape Start(End.size(), 0);
+  MlxShape Stride(End.size(), 1);
   Start[2] = Mask.size() - PadPatches;
   Mask = mlx::core::slice_update(
       Mask, mx::zeros({Mask.shape()[0], Mask.shape()[1], PadPatches}), Start,
@@ -318,7 +316,7 @@ mx::array _prepareAspectRatioAttentionMask(const mx::array &AspectRatioMask,
   float MinValue = -1e9f;
   mx::array MaskT = transpose(Mask, {0, 2, 1});
   mx::array AttnMask = mlx::core::matmul(Mask, MaskT) * MinValue;
-  std::vector<int> ReshapeDim = AttnMask.shape();
+  auto ReshapeDim = AttnMask.shape();
   ReshapeDim.insert(ReshapeDim.begin() + 1, 1);
   // attention_mask = attention_mask[:, None, :, :]
   AttnMask = reshape(AttnMask, ReshapeDim);

--- a/model/vlm_base.cpp
+++ b/model/vlm_base.cpp
@@ -1,4 +1,5 @@
 #include "vlm_base.h"
+#include "../mlx/mlx_compat.h"
 #include "base.h"
 #include "spdlog/spdlog.h"
 #include "vlm_sampling.h"
@@ -60,14 +61,14 @@ std::tuple<mx::array, mx::array> KVCache::fetch() const {
 
 void KVCache::update(const mx::array &NewKeys, const mx::array &NewValues) {
   int Prev = Offset;
-  std::vector<int> NewShape = NewKeys.shape();
+  auto NewShape = NewKeys.shape();
   int NewLen = NewShape[2];
 
   if (Keys.size() == 0 || (Prev + NewLen) > Keys.shape()[2]) {
     int NSteps = (Step + NewLen - 1) / Step;
     int NewCapacity = NSteps * Step;
-    std::vector<int> KShape = {1, NKVHeads, NewCapacity, KHeadDim};
-    std::vector<int> VShape = {1, NKVHeads, NewCapacity, VHeadDim};
+    MlxShape KShape = {1, NKVHeads, NewCapacity, KHeadDim};
+    MlxShape VShape = {1, NKVHeads, NewCapacity, VHeadDim};
     mx::array NewK = mx::zeros(KShape, NewKeys.dtype());
     mx::array NewV = mx::zeros(VShape, NewValues.dtype());
     if (Keys.size() != 0) {
@@ -88,8 +89,8 @@ void KVCache::update(const mx::array &NewKeys, const mx::array &NewValues) {
   // self.keys[..., prev : self.offset, :] = keys
   // self.values[..., prev : self.offset, :] = values
   auto End = NewKeys.shape();
-  std::vector<int> Start(End.size(), 0);
-  std::vector<int> Stride(End.size(), 1);
+  MlxShape Start(End.size(), 0);
+  MlxShape Stride(End.size(), 1);
   Start[End.size() - 2] = Prev;
   End[End.size() - 2] = Offset;
   Keys = mx::slice_update(Keys, NewKeys, Start, End, Stride);
@@ -195,7 +196,7 @@ std::tuple<mx::array, mx::array>
 RotatingKVCache::updateInPlace(const mx::array &NewKeys,
                                const mx::array &NewValues) {
   // May not have hit the max size yet, so potentially keep growing the cache
-  std::vector<int> KeysShape = NewKeys.shape();
+  auto KeysShape = NewKeys.shape();
   int B = KeysShape[0];
   int NKVHeads = KeysShape[1];
   int S = KeysShape[2];
@@ -206,8 +207,8 @@ RotatingKVCache::updateInPlace(const mx::array &NewKeys,
   if (Keys.size() == 0 ||
       (Prev >= Keys.shape()[2] && Keys.shape()[2] < MaxSize)) {
     int NewSize = std::min(Step, MaxSize - Prev);
-    std::vector<int> KShape = {B, NKVHeads, NewSize, KHeadDim};
-    std::vector<int> VShape = {B, NKVHeads, NewSize, VHeadDim};
+    MlxShape KShape = {B, NKVHeads, NewSize, KHeadDim};
+    MlxShape VShape = {B, NKVHeads, NewSize, VHeadDim};
 
     mx::array NewK = mx::zeros(KShape, NewKeys.dtype());
     mx::array NewV = mx::zeros(VShape, NewValues.dtype());
@@ -236,10 +237,10 @@ RotatingKVCache::updateInPlace(const mx::array &NewKeys,
   }
 
   // Assign
-  std::vector<int> KeysEnd = Keys.shape();
-  std::vector<int> Start(KeysEnd.size(), 0);
-  std::vector<int> ValuesEnd = Values.shape();
-  std::vector<int> Stride(KeysEnd.size(), 1);
+  auto KeysEnd = Keys.shape();
+  MlxShape Start(KeysEnd.size(), 0);
+  auto ValuesEnd = Values.shape();
+  MlxShape Stride(KeysEnd.size(), 1);
   Start[Start.size() - 2] = Idx;
   KeysEnd[KeysEnd.size() - 2] = Idx + S;
   ValuesEnd[KeysEnd.size() - 2] = Idx + S;
@@ -435,7 +436,7 @@ std::vector<int> Module::generate(
   }
 
   auto Step = [&](mx::array Y) -> std::tuple<mx::array, mx::array> {
-    std::vector<int> NewShape = Y.shape();
+    auto NewShape = Y.shape();
     NewShape.insert(NewShape.begin(), 1);
     // TODO: handle decoder_input_ids
     auto Outputs = std::dynamic_pointer_cast<vlm::LanguageModel>(

--- a/model/whisper/decoding.cpp
+++ b/model/whisper/decoding.cpp
@@ -1,4 +1,5 @@
 #include "decoding.h"
+#include "../../mlx/mlx_compat.h"
 #include "base.h"
 #include "tokenizer.h"
 #include "whisper.h"
@@ -630,8 +631,8 @@ DecodingTask::detectLanguage(const mx::array &AudioFeatures,
     LangProbs = Probabilities;
 
     if (!Options.Language) {
-      std::vector<int> Start = {0, SotIndex + 1};
-      std::vector<int> End = {Tokens.shape()[0], SotIndex + 2};
+      MlxShape Start = {0, SotIndex + 1};
+      MlxShape End = {Tokens.shape()[0], SotIndex + 2};
 
       Tokens = slice_update(Tokens, DetectedLanguageTokens, Start, End);
     }
@@ -737,7 +738,7 @@ std::vector<DecodingResult> DecodingTask::run(const mx::array &Mel) {
 
     // tokens = mx.broadcast_to(tokens, [n_audio, self.n_group,
     // len(self.initial_tokens)])
-    std::vector<int> NewShape = {NAudio, NGroup,
+    MlxShape NewShape = {NAudio, NGroup,
                                  static_cast<int>(InitialTokens.size())};
     Tokens = mx::broadcast_to(Tokens, NewShape);
 
@@ -770,8 +771,8 @@ std::vector<DecodingResult> DecodingTask::run(const mx::array &Mel) {
       Decoder->finalize(TokensResult, SumLogprobs);
 
   // tokens[..., self.sample_begin:]
-  std::vector<int> SliceStart(FinalizedTokens.ndim(), 0);
-  std::vector<int> SliceEnd = FinalizedTokens.shape();
+  MlxShape SliceStart(FinalizedTokens.ndim(), 0);
+  auto SliceEnd = FinalizedTokens.shape();
   SliceStart[FinalizedTokens.ndim() - 1] = SampleBegin;
   FinalizedTokens = mx::slice(FinalizedTokens, SliceStart, SliceEnd);
 

--- a/model/whisper/whisper.cpp
+++ b/model/whisper/whisper.cpp
@@ -1,4 +1,5 @@
 #include "whisper.h"
+#include "../../mlx/mlx_compat.h"
 #include "activations.h"
 #include "base.h"
 #include "convolution.h"
@@ -300,9 +301,9 @@ TextDecoder::forward(
       KvCache->at(0).first->first.shape(1) > 0) {
     Offset = KvCache->at(0).first->first.shape(1);
   }
-  std::vector<int> Start(Parameters.at("positional_embedding").shape().size(),
+  MlxShape Start(Parameters.at("positional_embedding").shape().size(),
                          0);
-  std::vector<int> End = Parameters.at("positional_embedding").shape();
+  auto End = Parameters.at("positional_embedding").shape();
   Start[0] = Offset;
   End[0] = Offset + X.shape(-1);
 

--- a/model/whisper_transcribe.cpp
+++ b/model/whisper_transcribe.cpp
@@ -1,4 +1,5 @@
 #include "whisper_transcribe.h"
+#include "../mlx/mlx_compat.h"
 #include "base.h"
 #include "spdlog/spdlog.h"
 #include "whisper/tokenizer.h"
@@ -84,9 +85,9 @@ mx::array padOrTrim(const mx::array &Array, int Length, int Axis) {
   int ActualAxis = Axis < 0 ? Shape.size() + Axis : Axis;
 
   if (Shape[ActualAxis] > Length) {
-    std::vector<int> Start(Shape.size(), 0);
-    std::vector<int> End = Shape;
-    std::vector<int> Strides(Shape.size(), 1);
+    MlxShape Start(Shape.size(), 0);
+    auto End = Shape;
+    MlxShape Strides(Shape.size(), 1);
     End[ActualAxis] = Length;
     return mx::slice(Array, Start, End, Strides);
   }
@@ -103,9 +104,9 @@ mx::array padOrTrim(const mx::array &Array, int Length, int Axis) {
 mx::array hanningWindow(int Size) {
   mx::array N = mx::arange(Size + 1);
   mx::array Window = 0.5f * (1.0f - mx::cos(2.0f * M_PI * N / Size));
-  std::vector<int> Start = {0};
-  std::vector<int> End = {-1};
-  std::vector<int> Strides = {1};
+  MlxShape Start = {0};
+  MlxShape End = {-1};
+  MlxShape Strides = {1};
   return mx::slice(Window, Start, End, Strides);
 }
 
@@ -122,9 +123,9 @@ mx::array stft(const mx::array &X, const mx::array &Window, int NPerseg = 256,
     }
     if (PadMode == "reflect") {
       // x[1:padding+1][::-1]
-      std::vector<int> Start(X.shape().size(), 0);
-      std::vector<int> End = X.shape();
-      std::vector<int> Strides(X.shape().size(), 1);
+      MlxShape Start(X.shape().size(), 0);
+      auto End = X.shape();
+      MlxShape Strides(X.shape().size(), 1);
 
       Start[0] = 1;
       End[0] = Padding + 1;
@@ -141,9 +142,9 @@ mx::array stft(const mx::array &X, const mx::array &Window, int NPerseg = 256,
   // Pad the signal
   int Padding = NPerseg / 2;
   auto Padded = Pad(X, Padding, PadMode);
-  std::vector<int64_t> Strides = {static_cast<int64_t>(NOverlap), 1};
+  MlxStrides Strides = {static_cast<int64_t>(NOverlap), 1};
   int T = (Padded.shape(0) - NPerseg + NOverlap) / NOverlap;
-  auto Shape = std::vector<int>{T, NfFt};
+  MlxShape Shape = {T, NfFt};
   auto StridedX = mx::as_strided(Padded, Shape, Strides, 0);
 
   return mx::fft::rfft(StridedX * Window);
@@ -171,10 +172,10 @@ mx::array logMelSpectrogram(const mx::array &Audio, int NMels, int Padding) {
   auto Freqs = stft(PaddedAudio, Window, DefaultNFft, DefaultHopLength,
                     DefaultNFft, "reflect");
   // freqs[:-1, :].abs().square()
-  std::vector<int> Start = {0, 0};
-  std::vector<int> End = {static_cast<int>(Freqs.shape(0) - 1),
+  MlxShape Start = {0, 0};
+  MlxShape End = {static_cast<int>(Freqs.shape(0) - 1),
                           static_cast<int>(Freqs.shape(1))};
-  std::vector<int> Strides = {1, 1};
+  MlxShape Strides = {1, 1};
   auto FreqsSliced = mx::slice(Freqs, Start, End, Strides);
   auto Magnitudes = mx::square(mx::abs(FreqsSliced));
   // Apply mel filters
@@ -518,8 +519,8 @@ transcribe(const std::variant<std::string, mx::array> &Audio,
           std::min({DefaultNFrames, ContentFrames - Seek, SeekClipEnd - Seek});
 
       // Extract mel segment
-      std::vector<int> Start(Mel.shape().size(), 0);
-      std::vector<int> End = Mel.shape();
+      MlxShape Start(Mel.shape().size(), 0);
+      auto End = Mel.shape();
       Start[0] = Seek;
       End[0] = Seek + SegmentSize;
       auto MelSegment = mx::slice(Mel, Start, End);


### PR DESCRIPTION
Add mlx_compat.h header with version detection and compatibility macros/wrappers to support both MLX <0.30 and >=0.30 APIs:

- MLX_VERSION_AT_LEAST() macro for version checking
- MlxShape/MlxStrides type aliases for shape types
- MLX_QUANTIZE_* macros for quantize result access
- mlx_compat::scaled_dot_product_attention() wrapper

This allows the library to compile with both older and newer MLX versions without source modifications.